### PR TITLE
Setup FetchInterceptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,8 @@
-# Mock Service Worker Example
+# Setup FetchInterceptor
 
-[Mock Service Worker](https://github.com/mswjs/msw) is an API mocking library for browser and Node. It provides seamless mocking by interception of actual requests on the network level using Service Worker API. This makes your application unaware of any mocking being at place.
-
-In this example we integrate Mock Service Worker with Next by following the next steps:
-
-1. Define a set of [request handlers](./mocks/handlers.ts) shared between client and server.
-1. Setup a [Service Worker instance](./mocks/browser.ts) that would intercept all runtime client-side requests via `setupWorker` function.
-1. Setup a ["server" instance](./mocks/server.ts) to intercept any server/build time requests (e.g. the one happening in `getServerSideProps`) via `setupServer` function.
-
-Mocking is enabled using the `NEXT_PUBLIC_API_MOCKING` environment variable. By default, mocking is enabled for both development and production. This allows you to have working preview deployments before implementing an actual API. To disable MSW for a specific environment, change the environment variable value in the file corresponding to the environment from `enabled` to `disabled`.
-
-The service worker file will automatically be generated in `public/mockServiceWorker.js` after installing `node_modules`. If the file is not generated, you can explicitly generate it with the following command:
-
-```bash
-npx msw init public/
-```
-
-More information on this setup step can be found in the MSW documentation [here](https://mswjs.io/docs/getting-started/integrate/browser#setup).
-
-## Deploy your own
-
-Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=next-example):
-
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https://github.com/vercel/next.js/tree/canary/examples/with-msw&project-name=with-msw&repository-name=with-msw)
-
-## How to use
-
-Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init), [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/), or [pnpm](https://pnpm.io) to bootstrap the example:
-
-```bash
-npx create-next-app --example with-msw with-msw-app
-```
-
-```bash
-yarn create next-app --example with-msw with-msw-app
-```
-
-```bash
-pnpm create next-app --example with-msw with-msw-app
-```
-
-Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).
+- git clone https://github.com/mswjs/msw.git
+- cd msw, make sure `node -v` is the same as the current project
+- npm link
+- back tothe project
+- npm link msw
+- npm run dev, you should be redirected to a hello page if it worked

--- a/mocks/edge.ts
+++ b/mocks/edge.ts
@@ -1,0 +1,184 @@
+import {
+  handleRequest,
+  MockedRequest,
+  RequestHandler,
+  SetupApi,
+  SharedOptions,
+} from "msw";
+import { invariant } from "outvariant";
+import { ServerLifecycleEventsMap } from "msw/lib/node";
+import { handlers } from "./handlers";
+import { FetchInterceptor } from "@mswjs/interceptors/lib/interceptors/fetch";
+import {
+  MockedResponse as MockedInterceptedResponse,
+  BatchInterceptor,
+  Interceptor,
+  HttpRequestEventMap,
+  InterceptorReadyState,
+} from "@mswjs/interceptors";
+
+// This needs an exported
+type Fn = (...arg: any[]) => any;
+type RequiredDeep<
+  Type,
+  U extends Record<string, unknown> | Fn | undefined = undefined
+> = Type extends Fn
+  ? Type
+  : /**
+   * @note The "Fn" type satisfies the predicate below.
+   * It must always come first, before the Record check.
+   */
+  Type extends Record<string, any>
+  ? {
+      [Key in keyof Type]-?: NonNullable<Type[Key]> extends NonNullable<U>
+        ? NonNullable<Type[Key]>
+        : RequiredDeep<NonNullable<Type[Key]>, U>;
+    }
+  : Type;
+const DEFAULT_LISTEN_OPTIONS: RequiredDeep<SharedOptions> = {
+  onUnhandledRequest: "warn",
+};
+export function isObject(value: any): boolean {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function mergeRight(
+  left: Record<string, any>,
+  right: Record<string, any>
+) {
+  return Object.entries(right).reduce((result, [key, rightValue]) => {
+    const leftValue = result[key];
+
+    if (Array.isArray(leftValue) && Array.isArray(rightValue)) {
+      result[key] = leftValue.concat(rightValue);
+      return result;
+    }
+
+    if (isObject(leftValue) && isObject(rightValue)) {
+      result[key] = mergeRight(leftValue, rightValue);
+      return result;
+    }
+
+    result[key] = rightValue;
+    return result;
+  }, Object.assign({}, left));
+}
+
+export class SetupEdge extends SetupApi<ServerLifecycleEventsMap> {
+  private resolvedOptions: RequiredDeep<SharedOptions>;
+  protected readonly interceptor: BatchInterceptor<
+    Array<Interceptor<HttpRequestEventMap>>,
+    HttpRequestEventMap
+  >;
+  constructor(
+    interceptors: Array<{
+      new (): any;
+    }>,
+    handlers: RequestHandler[]
+  ) {
+    super(handlers);
+
+    this.interceptor = new BatchInterceptor({
+      name: "setup-edge-server",
+      interceptors: interceptors.map((Interceptor) => new Interceptor()),
+    });
+    this.resolvedOptions = {} as RequiredDeep<SharedOptions>;
+
+    this.init();
+  }
+
+  public async init(): Promise<void> {
+    this.interceptor.on("request", async (request) => {
+      const mockedRequest = new MockedRequest(request.url, {
+        ...request,
+        body: await request.arrayBuffer(),
+      });
+
+      const response = await handleRequest<
+        MockedInterceptedResponse & { delay?: number }
+      >(
+        mockedRequest,
+        this.currentHandlers,
+        this.resolvedOptions,
+        this.emitter,
+        {
+          transformResponse(response) {
+            return {
+              status: response.status,
+              statusText: response.statusText,
+              headers: response.headers.all(),
+              body: response.body,
+              delay: response.delay,
+            };
+          },
+        }
+      );
+
+      if (response) {
+        // Delay Node.js responses in the listener so that
+        // the response lookup logic is not concerned with responding
+        // in any way. The same delay is implemented in the worker.
+        if (response.delay) {
+          await new Promise((resolve) => {
+            setTimeout(resolve, response.delay);
+          });
+        }
+
+        request.respondWith(response);
+      }
+
+      return;
+    });
+
+    this.interceptor.on("response", (request, response) => {
+      if (!request.id) {
+        return;
+      }
+
+      if (response.headers.get("x-powered-by") === "msw") {
+        this.emitter.emit("response:mocked", response, request.id);
+      } else {
+        this.emitter.emit("response:bypass", response, request.id);
+      }
+    });
+  }
+
+  public listen(options: Record<string, any> = {}): void {
+    this.resolvedOptions = mergeRight(
+      DEFAULT_LISTEN_OPTIONS,
+      options
+    ) as RequiredDeep<SharedOptions>;
+    this.interceptor.apply();
+
+    invariant(
+      [InterceptorReadyState.APPLYING, InterceptorReadyState.APPLIED].includes(
+        this.interceptor.readyState
+      ),
+      'Failed to start "setupServer": the interceptor failed to apply. This is likely an issue with the library and you should report it at "%s".',
+      "https://github.com/mswjs/msw/issues/new/choose"
+    );
+  }
+
+  public printHandlers() {
+    const handlers = this.listHandlers();
+
+    handlers.forEach((handler) => {
+      const { header, callFrame } = handler.info;
+
+      const pragma = handler.info.hasOwnProperty("operationType")
+        ? "[graphql]"
+        : "[rest]";
+
+      console.log(`\
+    Declaration: ${callFrame}
+    `);
+    });
+  }
+
+  public close(): void {
+    super.dispose();
+    this.interceptor.dispose();
+  }
+}
+
+export const edge = new SetupEdge([FetchInterceptor], handlers);

--- a/mocks/index.ts
+++ b/mocks/index.ts
@@ -1,13 +1,19 @@
 async function initMocks() {
-  if (typeof window === 'undefined') {
-    const { server } = await import('./server')
-    server.listen()
+  if (process.env.NEXT_RUNTIME) {
+    const { edge } = await import("./edge");
+    console.log("Mookcing Edge Function");
+    edge.listen();
+  } else if (typeof window === "undefined") {
+    const { server } = await import("./server");
+    console.log("Mookcing Sever Function");
+    server.listen();
   } else {
-    const { worker } = await import('./browser')
-    worker.start()
+    const { worker } = await import("./browser");
+    console.log("Mookcing Browser Function");
+    worker.start();
   }
 }
 
-initMocks()
+initMocks();
 
-export {}
+export {};


### PR DESCRIPTION
With the new setup API update from msw, I was able to set up our Edge API. However, I am now seeing two new errors that still need to be addressed before we can add this to our repo :
1. In middleware: `window` is not defined error. This is because the ctx.fetch uses only the node and browser fetch method depending on the environment, and the Edge's fetch method is a browser method run in the edge server, thus the `window` object is undefined. I think we can change the [useFetch Logic](https://github.com/mswjs/msw/blob/85ba8440f57d15e6ce948f2350488365e809dce5/src/context/fetch.ts#L11) to 
```ts
const useFetch: (input: RequestInfo, init?: RequestInit) => Promise<Response> =
  isNodeProcess()
    ? (input, init) =>
        import('node-fetch').then(({ default: nodeFetch }) =>
          (nodeFetch as unknown as typeof window.fetch)(input, init),
        )
    : globalThis.fetch
    ? globalThis.fetch
    : window.fetch
```
which seems to be working fine, however, I am not sure if this is something that can be used since `globalThis` is pretty general, we will need a PR to add this check.

2. `location` is not defined in the [fetch](https://github.com/mswjs/interceptors/blob/aff787ee28e58737662b31b93e2b7f24faad7beb/src/interceptors/fetch/index.ts#L50) setup. This will be tricky because I don't see a way for us to pass in a custom URL origin. We _could_ add a param in the `FetchInterceptor` constructor to input the URL. Perhaps something like 
```ts
constructor(origin) {
    super(FetchInterceptor.symbol)
    this.origin = origin
  }
```
#2 is no longer a problem because the @msw/interceptors repo recently had a breaking change update to refactor this function. However, when creating the Edge API, I will have to install @msw/interceptors locally and not use the interceptor functions from the @msw repo. e.g., `MockedResponse` is no longer being used.